### PR TITLE
fix: フロントエンドJavaScript/HTMLエラー修正

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -359,7 +359,7 @@
 
       data.unregistered_stores.forEach(function(store) {
         const li = document.createElement('li');
-        li.textContent = `${escapeHtml(store.store_name)} (${formatCurrency(store.total_amount)}, ${store.count}件)`;
+        li.textContent = `${escapeHtml(store.store)} (${formatCurrency(store.total_amount)}, ${store.count}件)`;
         unregisteredList.appendChild(li);
       });
 
@@ -403,6 +403,9 @@
    * @returns {string} エスケープ済みテキスト
    */
   function escapeHtml(text) {
+    if (text == null) {
+      return '';
+    }
     const map = {
       '&': '&amp;',
       '<': '&lt;',

--- a/templates/index.html
+++ b/templates/index.html
@@ -136,7 +136,7 @@
             name="spreadsheet_id"
             placeholder="例: 10RJcB-_pOqsxA-6mGZ..."
             required
-            pattern="[A-Za-z0-9_-]{30,}"
+            pattern="[A-Za-z0-9_\-]{30,}"
             aria-describedby="spreadsheetIdHelp"
           >
           <div id="spreadsheetIdHelp" class="form-text">


### PR DESCRIPTION
- templates/index.html: pattern属性のハイフンをエスケープ（Chrome v-flag対応）
- static/js/index.js: escapeHtml関数にnullチェック追加
- static/js/index.js: store.store_name → store.store に修正（バックエンドと整合性）