### PR TITLE
docs: ChatGPT分類フロー仕様書追加

### DIFF
--- a/.claude/01_development_docs/03_data_flow.md
+++ b/.claude/01_development_docs/03_data_flow.md
@@ -2,7 +2,7 @@
 
 ## 6.4 アプリケーションデータフロー
 
-### 6.4.1 CSV取込から反映までの流れ
+### 6.4.1 CSV取込から反映までの流れ（ChatGPT分類フロー対応版）
 
 ```
 1. CSVアップロード
@@ -15,21 +15,99 @@
    ↓
 5. 実行ボタン押下
    ↓
-6. マッピング照合
-   ├─ 登録済み店舗 → カテゴリ・列番号特定
-   └─ 未登録店舗 → 一時保存
+6. マッピング照合（SQLite: store_mappings）
+   ├─ 登録済み店舗 → カテゴリ・列番号特定 → Step 10へ
+   └─ 未登録店舗 → ChatGPT分類フローへ（Step 7）
    ↓
-7. 月別・カテゴリ別集計
+7. 未登録店舗抽出
+   ├─ ユニークな店舗名リスト作成
+   ├─ 金額・出現回数の集計
+   └─ ChatGPT API 呼び出し準備
    ↓
-8. スプレッドシート書き込み
+8. ChatGPT 自動分類（gpt_classifier.py）
+   ├─ 未登録店舗リスト送信
+   ├─ カテゴリマスタ（B～V列定義）送信
+   ├─ 分類ルール送信
+   ├─ JSON形式で分類結果を受信
+   └─ エラー時: デフォルトカテゴリ（H列: 雑貨費）で続行
+   ↓
+9. ユーザー確認・手修正フロー
+   ├─ ChatGPT分類結果を一覧表示（gpt_classification.html）
+   ├─ カテゴリ・列のドロップダウンで手修正可能
+   ├─ 確定ボタン押下 → SQLite登録（source='auto', priority=4）
+   └─ キャンセル → 未登録のまま処理続行（次回再分類）
+   ↓
+10. 月別・カテゴリ別集計
+   ↓
+11. スプレッドシート書き込み
    ├─ 対象年シート選択
    ├─ 該当月の行特定
    └─ カテゴリ列に金額加算
    ↓
-9. 結果表示
+12. 結果表示
    ├─ 処理サマリー
-   ├─ 未登録店舗リスト
+   ├─ ChatGPT分類結果サマリー（NEW）
+   ├─ 未登録店舗リスト（残存分）
    └─ 詳細ログ生成
+```
+
+### 6.4.1.1 ChatGPT分類フロー詳細
+
+#### 処理シーケンス
+```
+[未登録店舗検出]
+  → [ChatGPT API呼び出し]
+  → [分類結果パース]
+  → [ユーザー確認画面]
+  → [手修正（任意）]
+  → [確定]
+  → [SQLite一括登録]
+  → [既存フロー合流]
+```
+
+#### ChatGPT APIリクエスト形式
+```json
+{
+  "mode": "THINK",
+  "entries": [
+    {"store": "スターバックス", "amount": 560},
+    {"store": "イオンリテール", "amount": 1234}
+  ],
+  "categories": {
+    "C": "食材費",
+    "D": "外食費",
+    "E": "自己投資費",
+    "F": "書籍代",
+    "G": "家電",
+    "H": "雑貨費",
+    "I": "衣服・化粧費",
+    "J": "娯楽",
+    "K": "旅行費",
+    "O": "通信費",
+    "R": "個人娯楽",
+    "T": "サブスク"
+  },
+  "rules": [
+    "出力はJSONのみ",
+    "categoryとcolumnを必ず返す",
+    "分類不能は発生させず、すべて雑貨費（H列）に分類する"
+  ]
+}
+```
+
+#### ChatGPT APIレスポンス形式
+```json
+[
+  {"store": "スターバックス", "category": "外食費", "column": "D"},
+  {"store": "イオンリテール", "category": "食材費", "column": "C"}
+]
+```
+
+#### 必須プロンプト文
+```
+あなたは家計簿分類アシスタントです。
+以下のCSV明細に対して、指定された列カテゴリに分類してください。
+理由は返さず、JSONのみ返してください。
 ```
 
 ### 6.4.2 データ構造
@@ -72,6 +150,51 @@
 ### 6.4.4 エラーハンドリング
 
 - CSV読込失敗 → エラーメッセージ表示
-- マッピング未設定 → デフォルト列（B列）に振り分け
+- マッピング未設定 → デフォルト列（B列: 支払額）に振り分け
 - API書き込み失敗 → リトライ3回、失敗時ログ保存
-- 未登録店舗 → 一時リストに保存、ユーザー確認画面表示
+- 未登録店舗 → ChatGPT分類フローへ（自動分類試行）
+- **ChatGPT API失敗** → デフォルトカテゴリ（H列: 雑貨費）で処理続行、エラーログ記録
+- **SQLite書き込み失敗** → 分類結果を破棄、処理続行、最後に失敗内容報告
+- **ユーザーキャンセル** → 未登録のまま処理続行、次回CSVアップロード時に再分類
+
+### 6.4.5 データストレージ変更（JSON → SQLite移行）
+
+#### 移行前（v1.0）
+```json
+// config/mapping.json
+{
+  "version": "1.0",
+  "mappings": [
+    {
+      "id": 1,
+      "pattern": "ユシンヤ",
+      "match_type": "contains",
+      "category": "外食費",
+      "column": "C",
+      "priority": 1
+    }
+  ]
+}
+```
+
+#### 移行後（v2.0）
+```sql
+-- data/mappings.db: store_mappings テーブル
+CREATE TABLE store_mappings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    store TEXT NOT NULL,
+    pattern TEXT,
+    match_type TEXT NOT NULL DEFAULT 'contains',
+    category TEXT NOT NULL,
+    column TEXT NOT NULL,
+    priority INTEGER NOT NULL DEFAULT 4,
+    source TEXT NOT NULL DEFAULT 'manual',  -- 'manual' or 'auto'
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+#### 移行メリット
+- **高速検索**: インデックスによる効率的なマッチング
+- **トランザクション**: データ整合性保証
+- **バッチ登録**: ChatGPT分類結果の一括INSERT
+- **拡張性**: 統計情報、履歴管理の容易化

--- a/.claude/02_backend/00_backend_architecture.md
+++ b/.claude/02_backend/00_backend_architecture.md
@@ -67,7 +67,7 @@ project_root/
 
 **ChatGPT API認証**（NEW）
 - OpenAI API Key: 環境変数`OPENAI_API_KEY`で管理
-- モデル: GPT-4o-mini（コスト効率重視）
+- モデル: GPT-5
 - 用途: 未登録店舗の自動カテゴリ分類
 
 ---

--- a/.claude/02_backend/00_backend_architecture.md
+++ b/.claude/02_backend/00_backend_architecture.md
@@ -24,21 +24,34 @@
 
 ```
 project_root/
-├── app.py                    # メインアプリケーション
+├── app.py                       # メインアプリケーション
 ├── config/
-│   ├── mapping.json          # カテゴリマッピング
-│   └── service_account.json  # Google認証情報
-├── templates/                # Jinja2テンプレート
+│   ├── mapping.json             # カテゴリマッピング（廃止予定、SQLite移行中）
+│   └── service_account.json     # Google認証情報
+├── data/
+│   ├── mappings.db              # SQLiteマッピングDB（NEW）
+│   ├── backups/                 # バックアップ
+│   └── sessions/                # セッションストア
+│       └── sessions.db          # SQLiteセッションDB
+├── templates/                   # Jinja2テンプレート
 │   ├── index.html
 │   ├── mapping.html
-│   └── result.html
-├── static/                   # 静的ファイル
-│   ├── css/style.css
-│   └── js/app.js
-├── modules/                  # ビジネスロジック
-│   ├── csv_parser.py        # CSV解析
-│   ├── category_matcher.py  # カテゴリ判定
-│   └── sheets_client.py     # Google Sheets連携
+│   ├── result.html
+│   └── gpt_classification.html  # ChatGPT分類確認画面（NEW）
+├── static/                      # 静的ファイル
+│   ├── css/
+│   │   └── style.css
+│   └── js/
+│       ├── main.js
+│       ├── mapping.js
+│       └── gpt_classification.js  # ChatGPT分類確認用JS（NEW）
+├── modules/                     # ビジネスロジック
+│   ├── csv_processor.py         # CSV解析
+│   ├── category_logic.py        # カテゴリ判定
+│   ├── sheets_api.py            # Google Sheets連携
+│   ├── mapping_manager.py       # マッピング管理
+│   ├── session_store.py         # セッションストア
+│   └── gpt_classifier.py        # ChatGPT分類モジュール（NEW）
 ├── requirements.txt
 ├── Dockerfile
 └── docker-compose.yml
@@ -51,3 +64,65 @@ project_root/
 - プロジェクトID: `creditapi-470614`
 - 完全自動化、ブラウザ認証不要
 - 認証情報ファイル（JSON）をDocker内に配置
+
+**ChatGPT API認証**（NEW）
+- OpenAI API Key: 環境変数`OPENAI_API_KEY`で管理
+- モデル: GPT-4o-mini（コスト効率重視）
+- 用途: 未登録店舗の自動カテゴリ分類
+
+---
+
+## ChatGPT分類フロー（NEW）
+
+### 概要
+未登録店舗をChatGPT APIで自動分類し、ユーザー確認後にSQLiteのstore_mappingsテーブルに登録する機能。
+
+### フロー図
+```
+1. CSVアップロード
+   ↓
+2. CSV解析（csv_processor.py）
+   ↓
+3. 未登録店舗抽出（category_logic.py）
+   ├─ 登録済み店舗 → 既存フロー
+   └─ 未登録店舗 → ChatGPT分類フローへ
+   ↓
+4. ChatGPT API 呼び出し（gpt_classifier.py）
+   ├─ 未登録店舗リスト送信
+   ├─ カテゴリマスタ送信
+   └─ 分類ルール送信
+   ↓
+5. ChatGPT 分類結果取得
+   ↓
+6. ユーザー確認画面表示（gpt_classification.html）
+   ├─ 分類結果一覧表示
+   ├─ 手修正可能
+   └─ 確定ボタン
+   ↓
+7. 確定後、SQLite登録（mapping_manager.py）
+   ├─ source='auto'
+   ├─ priority=4
+   └─ store_mappingsテーブルに一括INSERT
+   ↓
+8. 既存フローに合流
+   ↓
+9. カテゴリ判定（category_logic.py）
+   ↓
+10. Google Sheets 更新（sheets_api.py）
+   ↓
+11. 処理結果表示
+```
+
+### エラーハンドリング方針
+- **GPT API失敗時**: デフォルトカテゴリ（H列: 雑貨費）で処理続行
+- **SQLite書き込み失敗時**: 分類結果を破棄し、処理続行。最後に失敗内容を報告
+- **ユーザーキャンセル時**: 未登録のまま処理続行、次回CSVアップロード時に再分類
+
+### セキュリティ要件
+- OpenAI API Key は環境変数で管理（`.env`ファイル、`.gitignore`対象）
+- API呼び出し回数制限（レート制限対応）
+- ユーザー確認を必須とし、自動登録は行わない
+
+### パフォーマンス目標
+- 未登録店舗50件を一括分類: 10秒以内
+- ユーザー確認画面のレスポンス: 2秒以内

--- a/.claude/02_backend/01_backend_api_routes.md
+++ b/.claude/02_backend/01_backend_api_routes.md
@@ -17,10 +17,18 @@ POST /process       # CSV処理を実行してスプレッドシート更新
 ### マッピング管理
 ```
 GET  /mapping                 # マッピング管理画面を表示
-GET  /mapping/list            # マッピング一覧をJSON取得
-POST /mapping/add             # 新規マッピング追加
-PUT  /mapping/edit/<id>       # マッピング編集
-DELETE /mapping/delete/<id>   # マッピング削除
+GET  /mapping/list            # マッピング一覧をJSON取得（SQLite: store_mappings）
+POST /mapping/add             # 新規マッピング追加（SQLite INSERT）
+PUT  /mapping/edit/<id>       # マッピング編集（SQLite UPDATE）
+DELETE /mapping/delete/<id>   # マッピング削除（SQLite DELETE）
+```
+
+### ChatGPT分類機能（NEW）
+```
+POST /gpt/classify            # 未登録店舗をChatGPTで自動分類
+GET  /gpt/classification      # ChatGPT分類結果確認画面を表示
+POST /gpt/confirm             # ユーザー確認後、SQLiteに一括登録
+POST /gpt/cancel              # ChatGPT分類をキャンセル
 ```
 
 ### データ取得
@@ -34,8 +42,11 @@ GET  /download/log  # 処理ログをダウンロード
 GET  /static/<path> # CSS/JSファイル
 ```
 
+---
+
 ## データフロー
 
+### 従来フロー（～v1.0）
 1. **CSVアップロード** (`POST /upload`)
    - Shift_JIS → UTF-8 変換
    - ファイル保存
@@ -46,7 +57,7 @@ GET  /static/<path> # CSS/JSファイル
    - プレビュー5件返却
 
 3. **カテゴリ判定** (`POST /process`)
-   - 各店舗名をマッピングテーブルで照合
+   - 各店舗名をマッピングテーブル（JSON）で照合
    - カテゴリと列番号を決定
    - 未登録店舗をリスト化
 
@@ -60,107 +71,173 @@ GET  /static/<path> # CSS/JSファイル
    - 未登録店舗リスト
    - 処理詳細ログ
 
-## レスポンス形式
+---
 
-**成功時（JSON）**
+### ChatGPT分類フロー（v2.0～）
+
+1. **CSVアップロード** (`POST /upload`)
+   - Shift_JIS → UTF-8 変換
+   - ファイル保存
+
+2. **CSV解析** (`POST /preview`)
+   - 明細データ抽出（6桁日付の行）
+   - YYMMDD → YYYY/MM/DD 変換
+   - プレビュー5件返却
+
+3. **カテゴリ判定** (`POST /process`)
+   - 各店舗名をマッピングテーブル（SQLite: store_mappings）で照合
+   - 登録済み店舗 → カテゴリと列番号を決定 → Step 6へ
+   - 未登録店舗 → ChatGPT分類フローへ
+
+4. **ChatGPT自動分類** (`POST /gpt/classify`)
+   - 未登録店舗リスト抽出（ユニーク化）
+   - カテゴリマスタ送信（B～V列定義）
+   - ChatGPT API 呼び出し（gpt_classifier.py）
+   - JSON形式で分類結果を受信
+   - エラー時: デフォルトカテゴリ（H列: 雑貨費）で続行
+
+5. **ユーザー確認** (`GET /gpt/classification`)
+   - ChatGPT分類結果を一覧表示（gpt_classification.html）
+   - 店舗名、分類結果（カテゴリ、列）、金額、出現回数を表示
+   - ドロップダウンで手修正可能
+   - 確定ボタン → `POST /gpt/confirm` へ
+   - キャンセルボタン → `POST /gpt/cancel` へ
+
+6. **分類結果登録** (`POST /gpt/confirm`)
+   - ユーザー確認済み分類結果をSQLiteに一括INSERT
+   - store_mappingsテーブルに登録
+     - source='auto'
+     - priority=4
+   - トランザクション処理（全件成功 or 全件ロールバック）
+   - 失敗時: エラーログ記録、ユーザーに通知
+
+7. **Google Sheets連携**
+   - サービスアカウント認証
+   - 年シート・月行・カテゴリ列を特定
+   - 既存値に新規金額を加算
+
+8. **結果表示** (`GET /result`)
+   - 月別・カテゴリ別サマリー
+   - ChatGPT分類結果サマリー（NEW）
+   - 未登録店舗リスト（残存分）
+   - 処理詳細ログ
+
+---
+
+## エンドポイント詳細
+
+### POST /gpt/classify
+
+#### リクエスト
+```json
+{
+  "unregistered_stores": [
+    {"store": "スターバックス", "amount": 560, "count": 3},
+    {"store": "イオンリテール", "amount": 1234, "count": 1}
+  ]
+}
+```
+
+#### レスポンス（成功時）
 ```json
 {
   "status": "success",
   "data": {
-    "summary": {
-      "total_amount": 27575,
-      "total_count": 17,
-      "by_category": {...}
-    },
-    "unregistered_stores": [...]
+    "classifications": [
+      {"store": "スターバックス", "category": "外食費", "column": "D"},
+      {"store": "イオンリテール", "category": "食材費", "column": "C"}
+    ]
   }
 }
 ```
 
-**エラー時（JSON）**
+#### レスポンス（エラー時）
 ```json
 {
   "status": "error",
-  "message": "エラー内容",
-  "code": "ERROR_CODE"
+  "message": "ChatGPT API failed, using default category",
+  "data": {
+    "classifications": [
+      {"store": "スターバックス", "category": "雑貨費", "column": "H"},
+      {"store": "イオンリテール", "category": "雑貨費", "column": "H"}
+    ]
+  }
 }
 ```
 
 ---
 
-## ダウンロード方法
+### GET /gpt/classification
 
-このファイルをダウンロードするには、以下の手順で操作してください：
+#### レスポンス
+ChatGPT分類結果確認画面（gpt_classification.html）を表示
 
-1. このテキスト全体を選択してコピー
-2. テキストエディタに貼り付け
-3. ファイル名を `backend_api_routes.md` として保存
+#### 画面内容
+- ChatGPT分類結果一覧テーブル
+  - 店舗名
+  - 分類結果（カテゴリ、列）
+  - 金額
+  - 出現回数
+  - 編集ボタン（ドロップダウン）
+- 確定ボタン（`POST /gpt/confirm`）
+- キャンセルボタン（`POST /gpt/cancel`）
 
-または、ブラウザの「名前を付けて保存」機能をご利用ください。# バックエンドAPIルート設計
+---
 
-## エンドポイント一覧
+### POST /gpt/confirm
 
-### メイン画面
-```
-GET  /              # index.htmlを表示
-```
-
-### CSVアップロード・処理
-```
-POST /upload        # CSVファイルをアップロード
-POST /preview       # CSVプレビューを取得
-POST /process       # CSV処理を実行してスプレッドシート更新
-```
-
-### マッピング管理
-```
-GET  /mapping                 # マッピング管理画面を表示
-GET  /mapping/list            # マッピング一覧をJSON取得
-POST /mapping/add             # 新規マッピング追加
-PUT  /mapping/edit/<id>       # マッピング編集
-DELETE /mapping/delete/<id>   # マッピング削除
+#### リクエスト
+```json
+{
+  "classifications": [
+    {"store": "スターバックス", "category": "外食費", "column": "D"},
+    {"store": "イオンリテール", "category": "食材費", "column": "C"}
+  ]
+}
 ```
 
-### データ取得
+#### レスポンス（成功時）
+```json
+{
+  "status": "success",
+  "message": "Classifications saved to database",
+  "data": {
+    "saved_count": 2,
+    "failed_count": 0
+  }
+}
 ```
-GET  /result        # 処理結果を表示
-GET  /download/log  # 処理ログをダウンロード
+
+#### レスポンス（エラー時）
+```json
+{
+  "status": "error",
+  "message": "Database write failed",
+  "data": {
+    "saved_count": 1,
+    "failed_count": 1,
+    "failed_stores": ["イオンリテール"]
+  }
+}
 ```
 
-### 静的ファイル
+---
+
+### POST /gpt/cancel
+
+#### レスポンス
+```json
+{
+  "status": "success",
+  "message": "Classification cancelled"
+}
 ```
-GET  /static/<path> # CSS/JSファイル
-```
 
-## データフロー
-
-1. **CSVアップロード** (`POST /upload`)
-   - Shift_JIS → UTF-8 変換
-   - ファイル保存
-
-2. **CSV解析** (`POST /preview`)
-   - 明細データ抽出（6桁日付の行）
-   - YYMMDD → YYYY/MM/DD 変換
-   - プレビュー5件返却
-
-3. **カテゴリ判定** (`POST /process`)
-   - 各店舗名をマッピングテーブルで照合
-   - カテゴリと列番号を決定
-   - 未登録店舗をリスト化
-
-4. **Google Sheets連携**
-   - サービスアカウント認証
-   - 年シート・月行・カテゴリ列を特定
-   - 既存値に新規金額を加算
-
-5. **結果表示** (`GET /result`)
-   - 月別・カテゴリ別サマリー
-   - 未登録店舗リスト
-   - 処理詳細ログ
+---
 
 ## レスポンス形式
 
-**成功時（JSON）**
+### 成功時（JSON）
 ```json
 {
   "status": "success",
@@ -170,19 +247,65 @@ GET  /static/<path> # CSS/JSファイル
       "total_count": 17,
       "by_category": {...}
     },
+    "gpt_classification_summary": {
+      "classified_stores": 10,
+      "total_amount": 5680,
+      "failed_count": 0
+    },
     "unregistered_stores": [...]
   }
 }
 ```
 
-**エラー時（JSON）**
+### エラー時（JSON）
 ```json
 {
   "status": "error",
   "message": "エラー内容",
-  "code": "ERROR_CODE"
+  "code": "ERROR_CODE",
+  "details": "詳細なエラー情報"
 }
 ```
+
+---
+
+## エラーコード一覧
+
+| コード | 説明 | 対処法 |
+|-------|------|--------|
+| CSV_PARSE_ERROR | CSV解析失敗 | ファイル形式・エンコーディングを確認 |
+| GPT_API_ERROR | ChatGPT API失敗 | デフォルトカテゴリで続行、APIキー確認 |
+| DB_WRITE_ERROR | SQLite書き込み失敗 | データベースファイル権限確認 |
+| SHEETS_API_ERROR | Google Sheets API失敗 | 認証情報・権限確認 |
+| INVALID_REQUEST | 無効なリクエスト | リクエストパラメータ確認 |
+
+---
+
+## セキュリティ要件
+
+### 認証情報管理
+- OpenAI API Key: 環境変数`OPENAI_API_KEY`で管理（`.env`、`.gitignore`対象）
+- Google Service Account Key: `config/service_account.json`（`.gitignore`対象）
+
+### レート制限
+- ChatGPT API: 最大50件/リクエスト、exponential backoff でリトライ
+- Google Sheets API: batchUpdate使用、1秒あたり10リクエスト制限
+
+### データ検証
+- CSVファイルサイズ上限: 10MB（環境変数`CSV_MAX_FILE_SIZE`で調整可能）
+- 未登録店舗数上限: 100件/回（超過時は分割処理）
+
+---
+
+## パフォーマンス目標
+
+| エンドポイント | レスポンス時間 | スループット |
+|--------------|--------------|-------------|
+| POST /upload | < 2秒 | 10MB/2秒 |
+| POST /preview | < 1秒 | 1000件/1秒 |
+| POST /gpt/classify | < 10秒 | 50件/10秒 |
+| POST /gpt/confirm | < 2秒 | 100件/2秒 |
+| POST /process | < 30秒 | 1000件/30秒 |
 
 ---
 

--- a/.claude/02_backend/02_backend_modules_spec.md
+++ b/.claude/02_backend/02_backend_modules_spec.md
@@ -120,7 +120,7 @@ sheet.update_cell(row, column, new_value)
 
 ### 主要機能
 - 未登録店舗の自動カテゴリ分類
-- OpenAI GPT-4o-mini API 連携
+- OpenAI GPT-5 API 連携
 - カテゴリマスタの動的送信
 - エラーハンドリング（API失敗時のフォールバック）
 - レート制限対応
@@ -203,7 +203,7 @@ def apply_default_category(store: str) -> Dict:
 #### リクエスト形式
 ```python
 request_payload = {
-    "model": "gpt-4o-mini",
+    "model": "gpt-5",
     "messages": [
         {
             "role": "system",

--- a/.claude/02_backend/02_backend_modules_spec.md
+++ b/.claude/02_backend/02_backend_modules_spec.md
@@ -85,16 +85,16 @@ def get_unregistered_stores(records: List[Dict]) -> List[str]:
 ```python
 def authenticate(credentials_path: str) -> gspread.Client:
     """サービスアカウントで認証"""
-    
+
 def open_spreadsheet(client: Client, sheet_id: str) -> Spreadsheet:
     """スプレッドシートを開く"""
-    
+
 def get_year_sheet(spreadsheet: Spreadsheet, year: int) -> Worksheet:
     """年シートを取得"""
-    
+
 def update_cell(sheet: Worksheet, row: int, col: str, value: float):
     """セル値を更新（加算）"""
-    
+
 def batch_update(sheet: Worksheet, updates: List[Dict]):
     """複数セルを一括更新"""
 ```
@@ -113,6 +113,186 @@ new_value = current_value + amount
 # 更新実行
 sheet.update_cell(row, column, new_value)
 ```
+
+---
+
+## 4. ChatGPT分類モジュール（gpt_classifier.py）【NEW】
+
+### 主要機能
+- 未登録店舗の自動カテゴリ分類
+- OpenAI GPT-4o-mini API 連携
+- カテゴリマスタの動的送信
+- エラーハンドリング（API失敗時のフォールバック）
+- レート制限対応
+
+### 主要メソッド
+```python
+def classify_unregistered_stores(
+    unregistered_stores: List[Dict],
+    category_master: Dict[str, str]
+) -> List[Dict]:
+    """
+    未登録店舗をChatGPTで分類
+
+    Args:
+        unregistered_stores: 未登録店舗リスト
+            [{"store": "店舗名", "amount": 金額, "count": 出現回数}, ...]
+        category_master: カテゴリマスタ
+            {"C": "食材費", "D": "外食費", ...}
+
+    Returns:
+        分類結果リスト
+            [{"store": "店舗名", "category": "カテゴリ名", "column": "列"}, ...]
+    """
+
+def build_gpt_request(
+    stores: List[Dict],
+    categories: Dict[str, str]
+) -> Dict:
+    """
+    ChatGPT APIリクエストを構築
+
+    Args:
+        stores: 店舗リスト
+        categories: カテゴリマスタ
+
+    Returns:
+        GPT APIリクエストペイロード
+    """
+
+def parse_gpt_response(response: str) -> List[Dict]:
+    """
+    ChatGPT APIレスポンスをパース
+
+    Args:
+        response: GPT API レスポンス（JSON文字列）
+
+    Returns:
+        パース済み分類結果リスト
+
+    Raises:
+        ValueError: JSON解析失敗時
+    """
+
+def validate_classification_result(result: Dict) -> bool:
+    """
+    分類結果の妥当性を検証
+
+    Args:
+        result: 分類結果
+            {"store": "店舗名", "category": "カテゴリ名", "column": "列"}
+
+    Returns:
+        True: 妥当、False: 不正
+    """
+
+def apply_default_category(store: str) -> Dict:
+    """
+    デフォルトカテゴリを適用（フォールバック処理）
+
+    Args:
+        store: 店舗名
+
+    Returns:
+        デフォルト分類結果（H列: 雑貨費）
+    """
+```
+
+### ChatGPT API 連携
+
+#### リクエスト形式
+```python
+request_payload = {
+    "model": "gpt-4o-mini",
+    "messages": [
+        {
+            "role": "system",
+            "content": (
+                "あなたは家計簿分類アシスタントです。\n"
+                "以下のCSV明細に対して、指定された列カテゴリに分類してください。\n"
+                "理由は返さず、JSONのみ返してください。"
+            )
+        },
+        {
+            "role": "user",
+            "content": json.dumps({
+                "mode": "THINK",
+                "entries": [
+                    {"store": "スターバックス", "amount": 560},
+                    {"store": "イオンリテール", "amount": 1234}
+                ],
+                "categories": {
+                    "C": "食材費",
+                    "D": "外食費",
+                    "E": "自己投資費",
+                    "F": "書籍代",
+                    "G": "家電",
+                    "H": "雑貨費",
+                    "I": "衣服・化粧費",
+                    "J": "娯楽",
+                    "K": "旅行費",
+                    "O": "通信費",
+                    "R": "個人娯楽",
+                    "T": "サブスク"
+                },
+                "rules": [
+                    "出力はJSONのみ",
+                    "categoryとcolumnを必ず返す",
+                    "分類不能は発生させず、すべて雑貨費（H列）に分類する"
+                ]
+            }, ensure_ascii=False)
+        }
+    ],
+    "temperature": 0.3,
+    "response_format": {"type": "json_object"}
+}
+```
+
+#### レスポンス形式
+```json
+[
+  {"store": "スターバックス", "category": "外食費", "column": "D"},
+  {"store": "イオンリテール", "category": "食材費", "column": "C"}
+]
+```
+
+### エラーハンドリング
+
+```python
+try:
+    # ChatGPT API 呼び出し
+    result = classify_unregistered_stores(stores, categories)
+except OpenAIAPIError as e:
+    # API失敗時: デフォルトカテゴリで続行
+    logger.error(f"ChatGPT API error: {e}")
+    result = [apply_default_category(store["store"]) for store in stores]
+except JSONDecodeError as e:
+    # JSON解析失敗時: デフォルトカテゴリで続行
+    logger.error(f"JSON parse error: {e}")
+    result = [apply_default_category(store["store"]) for store in stores]
+except Exception as e:
+    # その他エラー: デフォルトカテゴリで続行
+    logger.error(f"Unexpected error: {e}")
+    result = [apply_default_category(store["store"]) for store in stores]
+```
+
+### パフォーマンス最適化
+- **バッチ処理**: 未登録店舗を一括送信（最大50件/リクエスト）
+- **キャッシング**: 同一店舗名の再分類を回避
+- **レート制限対応**: exponential backoff でリトライ
+- **タイムアウト設定**: 10秒以内に応答がない場合はタイムアウト
+
+### セキュリティ要件
+- OpenAI API Key は環境変数`OPENAI_API_KEY`で管理
+- `.env`ファイルに保存、`.gitignore`対象
+- API Keyのログ出力を禁止
+
+### テストケース
+1. **正常系**: 未登録店舗50件を一括分類、全件成功
+2. **異常系**: API失敗時、デフォルトカテゴリ（H列）で続行
+3. **異常系**: JSON解析失敗時、デフォルトカテゴリで続行
+4. **境界値**: 未登録店舗0件、空リスト返却
+5. **境界値**: 未登録店舗100件、バッチ分割処理
 
 ---
 

--- a/.claude/02_backend/03_mapping_table_definition.md
+++ b/.claude/02_backend/03_mapping_table_definition.md
@@ -1,72 +1,203 @@
 # マッピングテーブル定義書
 
 ## 概要
-店舗名とカテゴリ・列番号の対応関係を管理するテーブル。JSON形式で`config/mapping.json`に保存。
+店舗名とカテゴリ・列番号の対応関係を管理するテーブル。**SQLite**形式で`data/mappings.db`に保存。
+**移行方針**: 従来のJSON形式（`config/mapping.json`）から、データベース管理に移行。
 
-## データ構造
+## ストレージ形式の変更履歴
 
-| フィールド名 | 型 | 必須 | 説明 | 例 |
-|------------|-----|------|------|-----|
-| id | integer | ○ | マッピングID | 1 |
-| pattern | string | ○ | 店舗名パターン | "ユシンヤ" |
-| match_type | string | ○ | 一致方法 | "contains" |
-| category | string | ○ | カテゴリ名 | "外食費" |
-| column | string | ○ | 列番号（B～V） | "C" |
-| priority | integer | ○ | 優先順位（1=最高） | 1 |
-| note | string | - | 備考 | - |
+| バージョン | ストレージ形式 | ファイルパス | 備考 |
+|----------|-------------|------------|------|
+| v1.0 | JSON | config/mapping.json | 初期実装 |
+| v2.0 | SQLite | data/mappings.db | ChatGPT分類フロー対応、JSON形式から移行 |
 
-## match_type の値
+---
+
+## 1. store_mappings テーブル（メインテーブル）
+
+### テーブル定義
+
+| カラム名 | データ型 | NOT NULL | DEFAULT | 説明 | 例 |
+|---------|---------|---------|---------|-----|-----|
+| id | INTEGER | ○ | PRIMARY KEY AUTOINCREMENT | マッピングID | 1 |
+| store | TEXT | ○ | - | 店舗名（完全一致検索用） | "ユシンヤカマタテン" |
+| pattern | TEXT | - | NULL | 店舗名パターン（部分一致検索用） | "ユシンヤ" |
+| match_type | TEXT | ○ | 'contains' | 一致方法 | "contains" |
+| category | TEXT | ○ | - | カテゴリ名 | "外食費" |
+| column | TEXT | ○ | - | 列番号（B～V） | "D" |
+| priority | INTEGER | ○ | 4 | 優先順位（1=最高、4=ChatGPT自動分類） | 1 |
+| source | TEXT | ○ | 'manual' | データソース | "auto" / "manual" |
+| created_at | TIMESTAMP | ○ | CURRENT_TIMESTAMP | 登録日時 | "2025-08-15 10:30:00" |
+| updated_at | TIMESTAMP | - | NULL | 最終更新日時 | "2025-08-16 14:20:00" |
+| note | TEXT | - | NULL | 備考 | - |
+
+### SQLスキーマ定義
+```sql
+CREATE TABLE IF NOT EXISTS store_mappings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    store TEXT NOT NULL,
+    pattern TEXT,
+    match_type TEXT NOT NULL DEFAULT 'contains',
+    category TEXT NOT NULL,
+    column TEXT NOT NULL CHECK(length(column) = 1 AND column BETWEEN 'B' AND 'V'),
+    priority INTEGER NOT NULL DEFAULT 4 CHECK(priority BETWEEN 1 AND 5),
+    source TEXT NOT NULL DEFAULT 'manual' CHECK(source IN ('manual', 'auto')),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP,
+    note TEXT
+);
+
+-- インデックス作成
+CREATE INDEX IF NOT EXISTS idx_store_mappings_store ON store_mappings(store);
+CREATE INDEX IF NOT EXISTS idx_store_mappings_pattern ON store_mappings(pattern);
+CREATE INDEX IF NOT EXISTS idx_store_mappings_category ON store_mappings(category);
+CREATE INDEX IF NOT EXISTS idx_store_mappings_priority ON store_mappings(priority);
+CREATE INDEX IF NOT EXISTS idx_store_mappings_source ON store_mappings(source);
+```
+
+### match_type の値
+
+| 値 | 説明 | 使用例 |
+|-----|------|-------|
+| exact | 完全一致 | "セブンイレブン新宿店" = "セブンイレブン新宿店" |
+| startswith | 前方一致 | "セブンイレブン..." で始まる店舗名 |
+| contains | 部分一致 | "...セブン..." を含む店舗名 |
+| keyword | キーワード一致 | "セブン" OR "イレブン" を含む |
+
+### priority の値
+
+| 優先順位 | 値 | 説明 | source |
+|---------|---|------|--------|
+| 最高 | 1 | 手動で明示的に設定した最優先マッピング | manual |
+| 高 | 2 | 手動で設定した優先マッピング | manual |
+| 中 | 3 | 手動で設定した通常マッピング | manual |
+| 低 | 4 | ChatGPT自動分類で登録されたマッピング | auto |
+| 最低 | 5 | デフォルト列（B列）への振り分け | auto |
+
+### source の値
+
+| 値 | 説明 | 登録方法 |
+|-----|------|---------|
+| manual | 手動登録 | Web UIから手動で追加・編集 |
+| auto | 自動登録 | ChatGPT分類フローで自動登録 |
+
+---
+
+## 2. unregistered_stores テーブル（任意：未登録店舗管理用）
+
+### テーブル定義
+
+| カラム名 | データ型 | NOT NULL | DEFAULT | 説明 | 例 |
+|---------|---------|---------|---------|-----|-----|
+| id | INTEGER | ○ | PRIMARY KEY AUTOINCREMENT | レコードID | 1 |
+| store | TEXT | ○ | - | 未登録店舗名 | "新規店舗A" |
+| first_seen_date | DATE | ○ | - | 初回検出日 | "2025-08-15" |
+| last_seen_date | DATE | ○ | - | 最終検出日 | "2025-08-16" |
+| occurrence_count | INTEGER | ○ | 1 | 出現回数 | 5 |
+| total_amount | INTEGER | ○ | 0 | 合計金額 | 15000 |
+| status | TEXT | ○ | 'pending' | ステータス | "pending" / "classified" / "ignored" |
+| created_at | TIMESTAMP | ○ | CURRENT_TIMESTAMP | 登録日時 | "2025-08-15 10:30:00" |
+| updated_at | TIMESTAMP | - | NULL | 最終更新日時 | "2025-08-16 14:20:00" |
+
+### SQLスキーマ定義
+```sql
+CREATE TABLE IF NOT EXISTS unregistered_stores (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    store TEXT NOT NULL UNIQUE,
+    first_seen_date DATE NOT NULL,
+    last_seen_date DATE NOT NULL,
+    occurrence_count INTEGER NOT NULL DEFAULT 1,
+    total_amount INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'classified', 'ignored')),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
+);
+
+-- インデックス作成
+CREATE INDEX IF NOT EXISTS idx_unregistered_stores_store ON unregistered_stores(store);
+CREATE INDEX IF NOT EXISTS idx_unregistered_stores_status ON unregistered_stores(status);
+CREATE INDEX IF NOT EXISTS idx_unregistered_stores_last_seen ON unregistered_stores(last_seen_date);
+```
+
+### status の値
 
 | 値 | 説明 |
 |-----|------|
-| exact | 完全一致 |
-| startswith | 前方一致 |
-| contains | 部分一致 |
-| keyword | キーワード一致 |
+| pending | 未分類（ChatGPT分類待ち） |
+| classified | 分類済み（store_mappingsに登録済み） |
+| ignored | 無視（分類不要） |
 
-## JSON構造例
-```json
-{
-  "version": "1.0",
-  "mappings": [
-    {
-      "id": 1,
-      "pattern": "ユシンヤ",
-      "match_type": "contains",
-      "category": "外食費",
-      "column": "C",
-      "priority": 1
-    },
-    {
-      "id": 2,
-      "pattern": "AMAZON",
-      "match_type": "contains",
-      "category": "日用品費",
-      "column": "D",
-      "priority": 1
-    }
-  ],
-  "default": {
-    "category": "支払額",
-    "column": "B",
-    "note": "未分類はB列に振り分け"
-  }
-}
-```
-
-## インデックス
-- PRIMARY KEY: id
-- INDEX: pattern（検索用）
-- INDEX: category（カテゴリ別検索用）
+---
 
 ## マッチング処理順序
-1. 完全一致（exact）
-2. 前方一致（startswith）
-3. 部分一致（contains）
-4. キーワード一致（keyword）
-5. デフォルト列（B列）
 
-## 運用
-- 手動編集可能（JSON直接編集）
-- Web UIからの追加・編集・削除対応
-- インポート・エクスポート機能あり
+1. **完全一致（exact）** - priority昇順
+2. **前方一致（startswith）** - priority昇順
+3. **部分一致（contains）** - priority昇順
+4. **キーワード一致（keyword）** - priority昇順
+5. **デフォルト列（B列）** - priority=5
+
+**優先順位の適用**:
+- 同じmatch_typeの場合、priorityが**小さい**ものを優先
+- 例: priority=1（手動設定）> priority=4（ChatGPT自動分類）
+
+---
+
+## データ移行
+
+### JSON → SQLite 移行スクリプト例
+```python
+import json
+import sqlite3
+from datetime import datetime
+
+def migrate_json_to_sqlite(json_path, db_path):
+    """JSONマッピングデータをSQLiteに移行"""
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    for mapping in data.get('mappings', []):
+        cursor.execute('''
+            INSERT INTO store_mappings (store, pattern, match_type, category, column, priority, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        ''', (
+            mapping.get('pattern'),  # store
+            mapping.get('pattern'),  # pattern
+            mapping.get('match_type', 'contains'),
+            mapping.get('category'),
+            mapping.get('column'),
+            mapping.get('priority', 3),  # 既存データは手動設定として priority=3
+            'manual'
+        ))
+
+    conn.commit()
+    conn.close()
+```
+
+---
+
+## 運用方法
+
+### データ管理
+- **手動登録**: Web UIから追加・編集・削除
+- **自動登録**: ChatGPT分類フローで自動追加（source='auto', priority=4）
+- **バックアップ**: 定期的にSQLiteファイルをバックアップ（`data/backups/`）
+
+### パフォーマンス最適化
+- インデックスによる高速検索
+- トランザクション処理によるデータ整合性保証
+- バッチ更新によるChatGPT分類結果の一括登録
+
+### エクスポート・インポート
+- JSON形式へのエクスポート機能（互換性維持）
+- 他環境からのインポート機能
+
+---
+
+## 関連ドキュメント
+- [カテゴリマスタ定義](./04_category_master_definition.md)
+- [バックエンドモジュール仕様](./02_backend_modules_spec.md)
+- [データフロー](../01_development_docs/03_data_flow.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@ project_root/
 ├── config/
 │   └── service_account.json  # Google認証情報（.gitignore対象）
 ├── data/
-│   ├── mapping.json          # カテゴリマッピング
+│   ├── mapping.json          # カテゴリマッピング（廃止予定、v2.0でSQLite移行）
+│   ├── mappings.db           # SQLiteマッピングDB（v2.0～、NEW）
 │   ├── backups/              # マッピングバックアップ（.gitignore対象）
 │   └── sessions/             # セッションストア（.gitignore対象）
 │       └── sessions.db       # SQLiteセッションDB（.gitignore対象）
@@ -61,18 +62,21 @@ project_root/
 │   │   └── style.css     # カスタムCSS
 │   └── js/
 │       ├── main.js       # メイン画面用JS
-│       └── mapping.js    # マッピング管理用JS
-├── templates/                # Jinja2テンプレート（未実装）
+│       ├── mapping.js    # マッピング管理用JS
+│       └── gpt_classification.js  # ChatGPT分類確認用JS（v2.0～、NEW）
+├── templates/                # Jinja2テンプレート
 │   ├── base.html         # ベーステンプレート
 │   ├── index.html        # メイン画面
 │   ├── mapping.html      # マッピング管理画面
-│   └── result.html       # 処理結果画面
+│   ├── result.html       # 処理結果画面
+│   └── gpt_classification.html  # ChatGPT分類確認画面（v2.0～、NEW）
 └── modules/
     ├── csv_processor.py  # CSV処理モジュール
     ├── sheets_api.py     # Sheets API連携
-    ├── mapping_manager.py # マッピング管理
+    ├── mapping_manager.py # マッピング管理（v2.0でSQLite対応）
     ├── category_logic.py  # カテゴリ振り分けロジック
-    └── session_store.py   # セッションストア（SQLite）
+    ├── session_store.py   # セッションストア（SQLite）
+    └── gpt_classifier.py  # ChatGPT分類モジュール（v2.0～、NEW）
 ```
 
 ## Technology Stack
@@ -85,7 +89,8 @@ project_root/
 - **google-auth**: 2.23+ (OAuth認証)
 - **gspread**: 6.x (Google Sheets連携)
 - **chardet**: 文字コード検出
-- **SQLite**: 3.x (セッションストア、WALモード対応)
+- **SQLite**: 3.x (セッションストア、マッピングDB、WALモード対応)
+- **OpenAI API**: GPT-4o-mini (未登録店舗の自動カテゴリ分類、v2.0～)
 
 ### Frontend
 - **Bootstrap**: 5.3 (UIフレームワーク)
@@ -172,24 +177,34 @@ python app.py
 2. **カテゴリ自動判定**
    - 店舗名から外食費、日用品費、交通費などのカテゴリを自動振り分け
    - パターンマッチング（完全一致、前方一致、部分一致）
-   - 優先順位の適用
+   - 優先順位の適用（手動登録 > ChatGPT自動分類）
+   - **v2.0**: SQLiteマッピングDB対応（JSON形式から移行）
 
-3. **スプレッドシート自動更新**
+3. **ChatGPT自動分類機能（v2.0～、NEW）**
+   - 未登録店舗をChatGPT APIで自動カテゴリ分類
+   - ユーザー確認フロー（分類結果の手修正可能）
+   - SQLite一括登録（source='auto', priority=4）
+   - エラー時のフォールバック処理（デフォルトカテゴリ: H列 雑貨費）
+   - バッチ処理対応（最大50件/リクエスト）
+
+4. **スプレッドシート自動更新**
    - Googleスプレッドシートの該当する年・月・カテゴリに金額を自動加算
    - 年別シート選択（2025年、2024年など）
    - 月別行（1月～12月）・カテゴリ別列（B～V列）への書き込み
 
-4. **マッピング管理**
+5. **マッピング管理**
    - 店舗名とカテゴリの対応関係を管理・編集
    - CRUD操作（登録、更新、削除）
-   - JSON形式でデータ永続化
+   - **v1.0**: JSON形式でデータ永続化
+   - **v2.0**: SQLite形式で高速検索・トランザクション保証
 
-5. **未登録店舗管理**
+6. **未登録店舗管理**
    - マッピング未登録店舗の自動検知
    - 金額合計と処理件数の表示
    - 新規マッピング登録機能
+   - **v2.0**: ChatGPT自動分類フローへの誘導
 
-6. **セッション管理**
+7. **セッション管理**
    - 独自server_session_id実装（Flask標準session使用）
    - SQLiteベースのサーバーサイドセッションストア
    - Cookie 4KB制限の解消（大容量CSVデータ対応）
@@ -218,10 +233,18 @@ POST /process       # CSV処理実行・Sheets更新
 
 ### Mapping Management
 ```
-GET    /mapping/list            # マッピング一覧取得
-POST   /mapping/add             # 新規マッピング追加
-PUT    /mapping/edit/<id>       # マッピング編集
-DELETE /mapping/delete/<id>     # マッピング削除
+GET    /mapping/list            # マッピング一覧取得（SQLite: store_mappings）
+POST   /mapping/add             # 新規マッピング追加（SQLite INSERT）
+PUT    /mapping/edit/<id>       # マッピング編集（SQLite UPDATE）
+DELETE /mapping/delete/<id>     # マッピング削除（SQLite DELETE）
+```
+
+### ChatGPT Classification（v2.0～、NEW）
+```
+POST /gpt/classify            # 未登録店舗をChatGPTで自動分類
+GET  /gpt/classification      # ChatGPT分類結果確認画面を表示
+POST /gpt/confirm             # ユーザー確認後、SQLiteに一括登録
+POST /gpt/cancel              # ChatGPT分類をキャンセル
 ```
 
 ### Downloads
@@ -231,11 +254,24 @@ GET  /download/log  # 処理ログダウンロード
 
 ## Data Flow
 
+### 従来フロー（～v1.0）
 1. **CSVアップロード** → Shift_JIS → UTF-8 変換 → ファイル保存
 2. **CSV解析** → 明細データ抽出 → YYMMDD → YYYY/MM/DD 変換 → プレビュー返却
-3. **カテゴリ判定** → 店舗名マッピング照合 → カテゴリ・列番号決定 → 未登録店舗リスト化
+3. **カテゴリ判定** → 店舗名マッピング照合（JSON） → カテゴリ・列番号決定 → 未登録店舗リスト化
 4. **Google Sheets連携** → サービスアカウント認証 → 年シート・月行・カテゴリ列特定 → 金額加算
 5. **結果表示** → 月別・カテゴリ別サマリー → 未登録店舗リスト → 処理詳細ログ
+
+### ChatGPT分類フロー（v2.0～）
+1. **CSVアップロード** → Shift_JIS → UTF-8 変換 → ファイル保存
+2. **CSV解析** → 明細データ抽出 → YYMMDD → YYYY/MM/DD 変換 → プレビュー返却
+3. **カテゴリ判定** → 店舗名マッピング照合（SQLite: store_mappings）
+   - 登録済み店舗 → カテゴリ・列番号決定 → Step 7へ
+   - 未登録店舗 → ChatGPT分類フローへ
+4. **ChatGPT自動分類** → 未登録店舗抽出 → GPT API呼び出し → JSON分類結果受信
+5. **ユーザー確認** → 分類結果一覧表示 → 手修正可能 → 確定ボタン押下
+6. **SQLite登録** → 確定済み分類結果を一括INSERT（source='auto', priority=4）
+7. **Google Sheets連携** → サービスアカウント認証 → 年シート・月行・カテゴリ列特定 → 金額加算
+8. **結果表示** → 月別・カテゴリ別サマリー → ChatGPT分類サマリー → 未登録店舗リスト（残存分） → 処理詳細ログ
 
 ## Testing
 
@@ -243,6 +279,8 @@ GET  /download/log  # 処理ログダウンロード
 - CSVファイル処理テスト（正常/異常ケース、大容量ファイル）
 - Google Sheets API連携テスト（認証、書き込み、エラーリカバリー）
 - マッピング機能テスト（パターンマッチング、CRUD操作、データ永続化）
+- **v2.0**: SQLiteマッピングDBテスト（トランザクション、インデックス検索）
+- **v2.0**: ChatGPT分類機能テスト（API呼び出し、エラーハンドリング、フォールバック）
 - 集計処理テスト（計算ロジック、未登録店舗検知）
 - 統合テスト（エンドツーエンド、性能テスト）
 
@@ -254,6 +292,8 @@ GET  /download/log  # 処理ログダウンロード
 ### Performance Targets
 - 1000件データ処理時間: 30秒以内
 - 大容量ファイル対応: 10MB級（環境変数で上限調整可能）
+- **v2.0**: ChatGPT分類処理時間: 50件で10秒以内
+- **v2.0**: SQLiteマッピング検索: 1000件で1秒以内
 
 ## Security Considerations
 
@@ -264,13 +304,15 @@ GET  /download/log  # 処理ログダウンロード
 
 ### Credential Management
 - `config/service_account.json` は `.gitignore` 対象
+- **v2.0**: `OPENAI_API_KEY` は環境変数で管理（`.env`ファイル、`.gitignore`対象）
 - 認証情報ファイルはコンテナ内で安全に管理
 - 環境変数またはボリュームマウントで配置
 
 ### Data Security
 - CSVファイルは処理後自動削除
-- 機密情報（credentials.json等）は Git 管理対象外
+- 機密情報（credentials.json、.env等）は Git 管理対象外
 - サービスアカウント認証（OAuth不要）
+- **v2.0**: SQLiteマッピングDBは暗号化不要（機密情報なし）
 
 ### File Size Limits
 - **デフォルト上限**: 10MB（DoS攻撃防止）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ project_root/
 - **gspread**: 6.x (Google Sheets連携)
 - **chardet**: 文字コード検出
 - **SQLite**: 3.x (セッションストア、マッピングDB、WALモード対応)
-- **OpenAI API**: GPT-4o-mini (未登録店舗の自動カテゴリ分類、v2.0～)
+- **OpenAI API**: GPT-5 (未登録店舗の自動カテゴリ分類、v2.0～)
 
 ### Frontend
 - **Bootstrap**: 5.3 (UIフレームワーク)


### PR DESCRIPTION
- .claude/02_backend/03_mapping_table_definition.md: SQLiteテーブル定義追加
- .claude/02_backend/00_backend_architecture.md: ChatGPT分類フロー追加
- .claude/01_development_docs/03_data_flow.md: データフロー更新
- .claude/02_backend/02_backend_modules_spec.md: gpt_classifier.py仕様追加
- .claude/02_backend/01_backend_api_routes.md: ChatGPTエンドポイント追加
- CLAUDE.md: Technology Stack、Key Features更新

新機能:
- POST /gpt/classify - ChatGPT自動分類
- GET /gpt/classification - 分類結果確認画面
- POST /gpt/confirm - SQLite一括登録
- POST /gpt/cancel - キャンセル