### PR TITLE
fix: Issue #56 confirmed_data→classificationsキー名統一

### DIFF
--- a/app.py
+++ b/app.py
@@ -1014,7 +1014,7 @@ def gpt_confirm():
 
     Request JSON:
         {
-            'confirmed_data': [
+            'classifications': [
                 {
                     'store_name': str,
                     'category': str
@@ -1040,9 +1040,9 @@ def gpt_confirm():
     try:
         # バリデーション
         data = request.get_json()
-        confirmed_data = data.get('confirmed_data', [])
+        classifications = data.get('classifications', [])
 
-        if not confirmed_data:
+        if not classifications:
             logger.warning("確定データが空です")
             return jsonify({
                 'status': 'error',
@@ -1050,7 +1050,7 @@ def gpt_confirm():
             }), 400
 
         # Step 1: SQLiteマッピング登録
-        logger.info(f"マッピング登録開始: {len(confirmed_data)}件")
+        logger.info(f"マッピング登録開始: {len(classifications)}件")
         success_count = 0
         failed_mappings = []
 
@@ -1070,7 +1070,7 @@ def gpt_confirm():
             'サブスク': 'T'
         }
 
-        for store_data in confirmed_data:
+        for store_data in classifications:
             store_name = store_data.get('store_name')
             category = store_data.get('category')
             column = category_to_column.get(category)


### PR DESCRIPTION
フロントエンド（gpt_classification.js）とバックエンド（app.py）の
リクエストキー名の不一致を修正しました。

変更内容:
- app.py Line 1017: docstring内のキー名修正
- app.py Line 1043: 変数定義を confirmed_data → classifications に変更
- app.py Line 1045: バリデーション条件を修正
- app.py Line 1053: ログ出力を修正
- app.py Line 1073: ループ処理を修正

影響:
- 「確定データが空です」エラーの解消
- HTTP 400エラーの解消
- ChatGPT分類確認画面の「確定」ボタンが正常動作

検証:
- 構文エラーなし（py_compile確認済み）
- フロントエンドとの整合性確保

関連Issue: #56