### PR TITLE
fix: Issue #58 session_store.delete_session()メソッド名を修正

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,7 +600,7 @@ def process():
             # セッションクリア
             server_session_id = session.get('server_session_id')
             if server_session_id:
-                session_store.delete_session(server_session_id)
+                session_store.delete(server_session_id)
 
             logger.info("CSV処理完了")
 
@@ -1145,7 +1145,7 @@ def gpt_confirm():
         logger.info("Google Sheets更新完了")
 
         # セッションクリア
-        session_store.delete_session(server_session_id)
+        session_store.delete(server_session_id)
 
         # Step 3: トップ画面リダイレクト
         return jsonify({
@@ -1285,7 +1285,7 @@ def clear_session():
                 logger.info(f"アップロードファイルを削除: {file_path}")
 
             # セッションストアからデータ削除
-            session_store.delete_session(server_session_id)
+            session_store.delete(server_session_id)
             session.pop('server_session_id', None)
 
         logger.info("セッションクリア完了")


### PR DESCRIPTION
- 誤: session_store.delete_session(server_session_id)
- 正: session_store.delete(server_session_id)

修正箇所:
- Line 603: /process エンドポイント
- Line 1148: /gpt/confirm エンドポイント
- Line 1288: /clear_session エンドポイント

SessionStoreクラスには delete_session() メソッドが存在しないため、
正しいメソッド名 delete() に統一。