### PR TITLE
fix: Issue #70 セッションデータキー不一致とCSRF保護デコレータエラーを修正

### DIFF
--- a/app.py
+++ b/app.py
@@ -293,7 +293,6 @@ def result():
 # ==================== CSVアップロード機能 ====================
 
 @app.route('/upload', methods=['POST'])
-@csrf.protect
 def upload():
     """
     CSVファイルをアップロードして一時保存
@@ -395,7 +394,6 @@ def upload():
 
 
 @app.route('/preview', methods=['POST'])
-@csrf.protect
 def preview():
     """
     アップロードされたCSVファイルのプレビューを取得
@@ -486,7 +484,6 @@ def preview():
 
 
 @app.route('/process', methods=['POST'])
-@csrf.protect
 def process():
     """
     CSVデータを処理してGoogle Sheetsに反映
@@ -677,7 +674,6 @@ def mapping_list():
 
 
 @app.route('/mapping/add', methods=['POST'])
-@csrf.protect
 def mapping_add():
     """
     新規マッピングを追加
@@ -893,7 +889,6 @@ def mapping_delete(mapping_id: int):
 # ==================== ChatGPT分類API ====================
 
 @app.route('/gpt/classify', methods=['POST'])
-@csrf.protect
 def gpt_classify():
     """
     未登録店舗をChatGPTで自動分類
@@ -921,7 +916,7 @@ def gpt_classify():
     try:
         # 1. セッションストアから未登録店舗を取得
         session_data = session_store.load(get_server_session_id()) or {}
-        unregistered_stores = session_data.get('process_result', {}).get('unregistered_stores')
+        unregistered_stores = session_data.get('unregistered_stores')
 
         if not unregistered_stores or len(unregistered_stores) == 0:
             logger.warning("未登録店舗が存在しません")
@@ -1009,7 +1004,6 @@ def gpt_classification():
 
 
 @app.route('/gpt/confirm', methods=['POST'])
-@csrf.protect
 def gpt_confirm():
     """
     ユーザー確認後、ChatGPT分類結果をSQLiteに一括登録し、Google Sheetsに反映
@@ -1166,7 +1160,6 @@ def gpt_confirm():
 
 
 @app.route('/gpt/cancel', methods=['POST'])
-@csrf.protect
 def gpt_cancel():
     """
     ChatGPT分類をキャンセル
@@ -1260,7 +1253,6 @@ def request_entity_too_large(error):
 
 
 @app.route('/clear_session', methods=['POST'])
-@csrf.protect
 def clear_session():
     """
     セッションをクリアする


### PR DESCRIPTION
## 修正内容

### 1. CSRF保護デコレータエラー修正
- 問題: @csrf.protectデコレータが TypeError を引き起こす
- 原因: CSRFProtect(app)で既に自動保護されているため個別デコレータ不要
- 修正: @csrf.protectデコレータを8箇所削除
  - Line 296: /upload
  - Line 398: /preview
  - Line 489: /process
  - Line 680: /mapping/add
  - Line 896: /gpt/classify
  - Line 1012: /gpt/confirm
  - Line 1169: /gpt/cancel
  - Line 1263: /clear_session

### 2. セッションデータキー不一致修正（Issue #70）
- 問題: /processと/gpt/classifyでセッションキーが不一致
- 修正箇所: app.py Line 919
- 修正前: session_data.get('process_result', {}).get('unregistered_stores')
- 修正後: session_data.get('unregistered_stores')

## 検証結果

✅ 機能テスト: test_issue64_functional.py 全合格
✅ 画面テスト: Playwright MCP 5シナリオ全成功
✅ ChatGPT分類フロー: 正常動作確認

## 関連Issue

- Issue #70: セッションデータキー不一致
- Issue #64: ChatGPT分類ダイアログが表示されない（完全解決）