### PR TITLE
fix: Issue #98 マッピングフォームから一致方法入力を廃止し自動設定に変更

### DIFF
--- a/static/js/mapping.js
+++ b/static/js/mapping.js
@@ -401,7 +401,7 @@ function handleAddMapping() {
   // フォームデータ取得
   const formData = {
     pattern: $('#storeNameInput').val().trim(),
-    match_type: $('#matchTypeSelect').val(),
+    match_type: 'contains',
     category: $('#categorySelect').val(),
     column: $('#columnSelect').val()
   };
@@ -474,7 +474,6 @@ function showEditForm(mapping) {
   // フォームにデータを設定
   $('#editMappingId').val(mapping.id);
   $('#editStoreNameInput').val(mapping.pattern);
-  $('#editMatchTypeSelect').val(mapping.match_type);
   $('#editCategorySelect').val(mapping.category);
   $('#editColumnSelect').val(mapping.column);
 
@@ -519,7 +518,7 @@ function handleEditMapping() {
   // フォームデータ取得
   const formData = {
     pattern: $('#editStoreNameInput').val().trim(),
-    match_type: $('#editMatchTypeSelect').val(),
+    match_type: 'contains',
     category: $('#editCategorySelect').val(),
     column: $('#editColumnSelect').val()
   };

--- a/templates/mapping.html
+++ b/templates/mapping.html
@@ -141,23 +141,6 @@
           </div>
         </div>
 
-        <!-- 一致方法 -->
-        <div class="mb-3">
-          <label for="matchTypeSelect" class="form-label">
-            一致方法 <span class="text-danger">*</span>
-          </label>
-          <select class="form-select" id="matchTypeSelect" name="match_type" required>
-            <option value="">選択してください</option>
-            <option value="exact">完全一致</option>
-            <option value="startswith">前方一致</option>
-            <option value="contains" selected>部分一致</option>
-            <option value="keyword">キーワード一致</option>
-          </select>
-          <div class="invalid-feedback">
-            一致方法を選択してください
-          </div>
-        </div>
-
         <!-- カテゴリ -->
         <div class="mb-3">
           <label for="categorySelect" class="form-label">
@@ -256,22 +239,6 @@
           >
           <div class="invalid-feedback">
             店舗名パターンを入力してください
-          </div>
-        </div>
-
-        <!-- 一致方法 -->
-        <div class="mb-3">
-          <label for="editMatchTypeSelect" class="form-label">
-            一致方法 <span class="text-danger">*</span>
-          </label>
-          <select class="form-select" id="editMatchTypeSelect" name="match_type" required>
-            <option value="exact">完全一致</option>
-            <option value="startswith">前方一致</option>
-            <option value="contains">部分一致</option>
-            <option value="keyword">キーワード一致</option>
-          </select>
-          <div class="invalid-feedback">
-            一致方法を選択してください
           </div>
         </div>
 


### PR DESCRIPTION
- templates/mapping.html: 新規追加・編集フォームから「一致方法」選択フィールドを削除
- static/js/mapping.js: handleAddMapping/handleEditMapping の match_type を 'contains' 固定に変更、showEditForm の editMatchTypeSelect 参照を削除